### PR TITLE
Disable composer-asset-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,11 @@
             "web": "config/web.php"
         }
     },
+    "config": {
+        "fxp-asset": {
+            "enabled": false
+        }
+    },
     "minimum-stability": "dev",
     "repositories": [
         {


### PR DESCRIPTION
When I tried to install, I found the process very slow and noticed that composer-asset-plugin was scanning a lot of repos in the background (current install allows dev versions). Using `--no-plugins` to speed it up resulted in composer-config-plugin being disabled too and the app does not work without it.

Even though we do not use it, the composer-asset-plugin should be disabled in composer.json to avoid conflicts and improve speed.