### PR TITLE
added default foxy config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,11 @@
         }
     },
     "config": {
+        "foxy": {
+            "enable-packages": {
+                "*": true
+            }
+        },
         "fxp-asset": {
             "enabled": false
         }


### PR DESCRIPTION
- does NOT require foxy to be installed, but when you use it, look for package.json files in all repos by default