### PR TITLE
Add yiisoft/event-dispatcher to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
         "yiisoft/log": "^3.0@dev",
         "yiisoft/log-target-file": "^3.0@dev",
         "yiisoft/rbac": "^3.0@dev",
-        "yiisoft/view": "^3.0@dev"
+        "yiisoft/view": "^3.0@dev",
+        "yiisoft/event-dispatcher": "^3.0@dev"
     },
     "require-dev": {
         "foxy/foxy": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌

this **PR** fixes psr/event-dispatcher-implementation 1.0.0 no matching package found on **fresh install**

this happened because [yiisoft/view requires psr/event-dispatcher-implementation 1.0.0 as dependency](https://github.com/yiisoft/view/blob/master/composer.json#L24) 

![Screenshot from 2019-09-17 22-02-13](https://user-images.githubusercontent.com/17250137/65078851-33491b00-d99e-11e9-9438-c42db85379ac.png)
